### PR TITLE
fixed Boost.TR1 unordered_set include issue on Gentoo

### DIFF
--- a/BastetBlockChooser.hpp
+++ b/BastetBlockChooser.hpp
@@ -23,7 +23,7 @@
 
 #include "Well.hpp"
 
-#include <boost/tr1/tr1/unordered_set>
+#include <boost/tr1/unordered_set.hpp>
 #include <set>
 #include <boost/functional/hash.hpp>
 


### PR DESCRIPTION
*Note*: I am not a C++ coder nor knowing anything about C++11/Boost.TR1, so the simple path change might not be a correct solution.

----

On Gentoo with Boost 1.56.0-r1, using GCC-4.9.3:

    g++ -DNDEBUG -Wall   -c -o Ui.o Ui.cpp
    In file included from /usr/include/boost/tr1/tr1/unordered_set:9:0,
                     from BastetBlockChooser.hpp:26,
                     from Ui.cpp:22:
    /usr/include/boost/tr1/detail/config_all.hpp:164:41: fatal error: ../4.9.3/utility: No such file or directory
     #  include BOOST_TR1_STD_HEADER(utility)
                                             ^

Using clang-3.7.1-r100:

    clang++ -DNDEBUG -Wall   -c -o Ui.o Ui.cpp
    In file included from Ui.cpp:22:
    In file included from ./BastetBlockChooser.hpp:26:
    In file included from /usr/include/boost/tr1/tr1/unordered_set:9:
    /usr/include/boost/tr1/detail/config_all.hpp:158:17: fatal error: 'utility' file not found
    #  include_next <utility>
                    ^

Changing the include, as per the [Boost documentation][1] indicating, solves the issue.

[1]: http://www.boost.org/doc/libs/1_56_0/doc/html/boost_tr1/subject_list.html#boost_tr1.subject_list.unordered_set