### PR TITLE
Don't escape the scorer names

### DIFF
--- a/Config.cpp
+++ b/Config.cpp
@@ -187,7 +187,7 @@ namespace Bastet{
     for(int difficulty=0;difficulty<num_difficulties;++difficulty){
       int i=0;
       BOOST_FOREACH(const HighScore &hs, _hs[difficulty]){
-	ofs2<<str(scorer % difficulty % i) << " = \"" << hs.Scorer << "\"\n";
+	ofs2<<str(scorer % difficulty % i) << " = " << hs.Scorer << "\n";
 	ofs2<<str(score % difficulty % i) << " = " << hs.Score <<"\n";
 	i++;
       }


### PR DESCRIPTION
bastet writes the scores file using double-quotes around the name for some reason (probably to avoid some kind of injection?), but reads the file without removing the double-quotes. The scorer name then appears as `"tester"` instead of `tester` in the scoreboard, quitting the game makes bastet write `""tester""` as name. So every time the game scorer file is written, double-quotes get added to the scorer name.

Since bastet reads the scorer name from the scorer file without removing the double-quotes or (un-)escaping anything, the easiest way to work around this is to make bastet not write double-quotes around the scorer name.