### PR TITLE
Ui.cpp: always use "%s"-style format for printf()-style functions

### DIFF
--- a/Ui.cpp
+++ b/Ui.cpp
@@ -183,7 +183,7 @@ namespace Bastet{
 
     BorderedWindow w(d.y,d.x);
     wattrset((WINDOW *)w,COLOR_PAIR(20));
-    mvwprintw(w,0,0,message.c_str());
+    mvwprintw(w,0,0,"%s",message.c_str());
     w.RedrawBorder();
     wrefresh(w);
     PrepareUiGetch();
@@ -200,7 +200,7 @@ namespace Bastet{
     d.y+=3;
     BorderedWindow w(d.y,d.x);
     wattrset((WINDOW *)w,COLOR_PAIR(20));
-    mvwprintw(w,0,0,message.c_str());
+    mvwprintw(w,0,0,"%s",message.c_str());
     w.RedrawBorder();
     wrefresh(w);
     PrepareUiGetch();
@@ -221,7 +221,7 @@ namespace Bastet{
 
     BorderedWindow w(d.y,d.x);
     wattrset((WINDOW *)w,COLOR_PAIR(20));
-    mvwprintw(w,0,0,message.c_str());
+    mvwprintw(w,0,0,"%s",message.c_str());
     w.RedrawBorder();
     wrefresh(w);
     PrepareUiGetch();
@@ -239,7 +239,7 @@ namespace Bastet{
     BorderedWindow w(d.y,d.x);
     wattrset((WINDOW *)w,COLOR_PAIR(20));
     for(size_t i=0;i<choices.size();++i){
-      mvwprintw(w,i,4,choices[i].c_str());
+      mvwprintw(w,i,4,"%s",choices[i].c_str());
     }
     w.RedrawBorder();
     wrefresh(w);
@@ -290,7 +290,7 @@ namespace Bastet{
       Dot d=BoundingRect(msg );
       BorderedWindow w(d.y,d.x);
       wattrset((WINDOW *)w,COLOR_PAIR(20));
-      mvwprintw(w,0,0,msg.c_str());
+      mvwprintw(w,0,0,"%s",msg.c_str());
       w.RedrawBorder();
       ch=getch();
       switch(ch){


### PR DESCRIPTION
`ncuses-6.3` added printf-style function attributes and now makes
it easier to catch cases when user input is used in palce of format
string when built with CFLAGS=-Werror=format-security:

    Ui.cpp:293:16: error: format not a string literal and no format arguments [-Werror=format-security]
      293 |       mvwprintw(w,0,0,msg.c_str());
          |       ~~~~~~~~~^~~~~~~~~~~~~~~~~~~

Let's wrap all the missing places with "%s" format.