### PR TITLE
Add required include to build against musl libc

### DIFF
--- a/Ui.cpp
+++ b/Ui.cpp
@@ -27,6 +27,7 @@
 #include <boost/format.hpp>
 #include <boost/foreach.hpp>
 #include <boost/algorithm/string.hpp>
+#include <sys/select.h>
 
 using namespace std;
 using namespace boost;


### PR DESCRIPTION
Ui.cpp was missing the include for `sys/select.h` which prevented building using the musl libc (at least for Void Linux). This should fix that.